### PR TITLE
Validate estimate API inputs and pin Werkzeug

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -8,8 +8,18 @@ def estimate():
     try:
         nodes = int(request.args.get("nodes", 1))
         hours = int(request.args.get("hours", 1))
-    except ValueError:
-        return jsonify({"error": "Invalid input. 'nodes' and 'hours' must be integers."}), 400
+    except (ValueError, TypeError):
+        return (
+            jsonify({"error": "Invalid input. 'nodes' and 'hours' must be integers."}),
+            400,
+        )
+
+    if nodes <= 0 or hours <= 0:
+        return (
+            jsonify({"error": "'nodes' and 'hours' must be positive integers."}),
+            400,
+        )
+
     cost_per_node_hour = 10
     total_cost = nodes * hours * cost_per_node_hour
     return jsonify({"nodes": nodes, "hours": hours, "estimated_cost_usd": total_cost})

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,1 +1,2 @@
 Flask==2.2.5
+Werkzeug>=2.2,<3


### PR DESCRIPTION
## Summary
- validate positive integer parameters for the /estimate endpoint
- pin Werkzeug <3 to avoid incompatibility with Flask 2.2

## Testing
- `python -m py_compile app/app.py`
- `python - <<'PY'
from app.app import app, estimate

with app.test_request_context('/estimate?nodes=-2&hours=3'):
    resp = estimate()
    print('negative', resp[1], resp[0].json)

with app.test_request_context('/estimate?nodes=2&hours=3'):
    resp = estimate()
    print('valid', resp[1] if isinstance(resp, tuple) else 200, resp[0].json if isinstance(resp, tuple) else resp.json)

with app.test_request_context('/estimate?nodes=abc&hours=3'):
    resp = estimate()
    print('non-int', resp[1], resp[0].json)
PY`
- `pip install -r app/requirements.txt` *(fails: Could not find a version that satisfies the requirement Werkzeug<3,>=2.2)*

------
https://chatgpt.com/codex/tasks/task_e_689e4ce6505483319115a50761f68a34